### PR TITLE
move 'website' links to their targets, fixes #10

### DIFF
--- a/keywords/hybrid.md
+++ b/keywords/hybrid.md
@@ -16,8 +16,8 @@ type: book
 
 # HYBRID (Draft)
 
-### Jesse Stommel
-Assistant Professor, University of Wisconsin-Madison, [Website](http://www.jessestommel.com)
+### [Jesse Stommel](http://www.jessestommel.com)
+Assistant Professor, University of Wisconsin-Madison
 
 ---
 

--- a/keywords/interface.md
+++ b/keywords/interface.md
@@ -15,8 +15,8 @@ type: book
 
 # INTERFACE (Draft)
 
-### Kathi Inman Berens
-University of Southern California | Annenberg School of Communication | [Website](http://kathiiberens.com)
+### [Kathi Inman Berens](http://kathiiberens.com)
+University of Southern California | Annenberg School of Communication
 
 ---
 

--- a/keywords/praxis.md
+++ b/keywords/praxis.md
@@ -20,7 +20,7 @@ type: book
 # PRAXIS  (Draft)
 
 ### Bethany Nowviskie, Jeremy Boggs, and J. K. Purdom Lindblad 
-University of Virginia | Scholars' Lab | [Website](http://scholarslab.org/)
+University of Virginia | [Scholars' Lab](http://scholarslab.org/)
 
 ---
 

--- a/keywords/queer.md
+++ b/keywords/queer.md
@@ -15,8 +15,8 @@ type: book
 
 # QUEER (Draft)
 
-### Edmond Y. Chang
-Drew University | Department of English | [Website](http://www.edmondchang.com/)
+### [Edmond Y. Chang](http://www.edmondchang.com/)
+Drew University | Department of English
 
 ---
 


### PR DESCRIPTION
This just moves the links that say "website" to more logical places, so that the text "Jesse Stommel" links to `jessestommel.com`, and the text "Scholar's Lab" links to `scholarslab.org`. 